### PR TITLE
Raise exception, if board do not answer

### DIFF
--- a/bl60x_flash/main.py
+++ b/bl60x_flash/main.py
@@ -50,6 +50,8 @@ def handshake(ser):
 
 def expect_ok(ser):
     data = ser.read(2)
+    if len(data) < 2:
+        raise Exception('No answer')
     if data[0] != 0x4f or data[1] != 0x4b:
         err = ser.read(2)
         raise ValueError(binascii.hexlify(err))


### PR DESCRIPTION
If entering download mode failed, IndexError was raised. Raise exception informing user, that no answer was received, instead.